### PR TITLE
Fix: Fix eventCards slide 

### DIFF
--- a/client/src/component/EmptyState.jsx
+++ b/client/src/component/EmptyState.jsx
@@ -3,15 +3,22 @@ import CreateClub from "../pages/CreateClub";
 import Heading from "./Heading";
 
 const EmptyState = ({
-  title = "등록된 클럽이 없어요!",
+  page,
   subtitle = "클럽 개설하러가기",
   showReset = false,
 }) => {
+  console.log(page)
   return (
     <>
       <div className="flex flex-col justify-center items-center">
-        <div className="h-[60vh] flex flex-col gap-2 justify-center items-center">
-          <Heading center title={title} />
+        <div className="h-auto flex flex-col gap-2 justify-center items-center">
+          {
+            (page === "club" ? (
+              <Heading center title="등록된 클럽이 없어요!" />
+            ) : (
+              <Heading center title="등록된 이벤트가 없어요!" />
+            ))
+          }
           {showReset && (
             <>
               <CreateClub />

--- a/client/src/pages/Club.jsx
+++ b/client/src/pages/Club.jsx
@@ -121,7 +121,9 @@ function Club() {
                     }  gap-x-4 gap-y-4`}
                   >
                     {filteredClubList.length === 0 ? (
-                      <EmptyState showReset handleClubCategory={handleClubCategory} />
+                      <EmptyState showReset
+                      page="club"
+                      handleClubCategory={handleClubCategory} />
                     ) : filteredClubList ? (
                       filteredClubList?.map((item, i) => {
                         return (


### PR DESCRIPTION
1. Fix: Fix eventCards slide
  - 이벤트 카드 슬라이드가 최대 페이지를 넘어가더라도 계속 넘어가는 현상 수정.
  - 이벤트 카드 슬라이드의 마지막페이지가 홀수일때 슬라이드가 한장만 출력되도록 수정.
 
2. Modify: Modify EmptyState
  - EmptyState를 club페이지와 detail페이지에서 모두 사용하기 위해 page prop으로 구분하여 출력함
